### PR TITLE
Implement back button for easier dismiss and add props for customization 

### DIFF
--- a/example/src/application.tsx
+++ b/example/src/application.tsx
@@ -42,6 +42,7 @@ const Application: React.FC = () => {
             phoneNumber={phoneNumber}
             setPhoneNumber={setPhoneNumber}
             showFirstOnList={countriesToShowFirst}
+            modalStyle={Platform.OS === 'web' ? styles.web : undefined}
           />
           <Surface elevation={5} style={styles.country}>
             <View style={styles.left}>
@@ -144,6 +145,13 @@ const styles = StyleSheet.create({
   actions: {
     flexDirection: 'row',
     justifyContent: 'space-evenly',
+  },
+  web: {
+    width: '40%',
+    height: '80%',
+    marginHorizontal: 'auto',
+    marginTop: 'auto',
+    marginBottom: 'auto',
   },
 });
 

--- a/src/CountryPicker.tsx
+++ b/src/CountryPicker.tsx
@@ -18,11 +18,11 @@ import {
   TouchableRipple,
   useTheme,
 } from 'react-native-paper';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { countries } from './data/countries';
+import type { CountryPickerProps, CountryPickerRef, RNPaperTextInputRef } from './types';
 import { useDebouncedValue } from './use-debounced-value';
 import { getCountryByCode } from './utils';
-import type { CountryPickerProps, CountryPickerRef, RNPaperTextInputRef } from './types';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 const isIOS = Platform.OS === 'ios';
 
@@ -35,7 +35,8 @@ export const CountryPicker = forwardRef<CountryPickerRef, CountryPickerProps>(
       // Prpos from TextInput that needs special handling
       disabled,
       editable = true,
-      keyboardType,
+      modalStyle,
+      modalContainerStyle,
       // rest of the props
       ...rest
     },
@@ -138,20 +139,16 @@ export const CountryPicker = forwardRef<CountryPickerRef, CountryPickerProps>(
         </TouchableRipple>
         <Portal>
           <Modal
-            style={{
-              backgroundColor: theme.colors.background,
-              marginTop: undefined,
-              marginBottom: undefined,
-              justifyContent: undefined,
-              paddingTop: insets.top,
-              paddingBottom: insets.bottom,
-            }}
-            contentContainerStyle={[
-              styles.countries,
+            style={[
+              styles.modal,
               {
-                justifyContent: undefined,
+                backgroundColor: theme.colors.background,
+                paddingTop: insets.top,
+                paddingBottom: insets.bottom,
               },
+              modalStyle,
             ]}
+            contentContainerStyle={[styles.countries, modalContainerStyle]}
             visible={visible}
             onDismiss={() => setVisible(false)}
           >
@@ -205,10 +202,16 @@ const styles = StyleSheet.create({
   flex1: {
     flex: isIOS ? undefined : 1,
   },
+  modal: {
+    marginTop: undefined,
+    marginBottom: undefined,
+    justifyContent: undefined,
+  },
   countries: {
     padding: 16,
     flex: isIOS ? undefined : 1,
     marginBottom: isIOS ? 150 : undefined,
+    justifyContent: undefined,
   },
   searchbox: {
     flexDirection: 'row',

--- a/src/PhoneNumberInput.tsx
+++ b/src/PhoneNumberInput.tsx
@@ -31,6 +31,8 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputRef, PhoneNumberInput
       disabled,
       editable = true,
       keyboardType,
+      modalStyle,
+      modalContainerStyle,
       // rest of the props
       ...rest
     },
@@ -150,20 +152,16 @@ export const PhoneNumberInput = forwardRef<PhoneNumberInputRef, PhoneNumberInput
         </TouchableRipple>
         <Portal>
           <Modal
-            style={{
-              backgroundColor: theme.colors.background,
-              marginTop: undefined,
-              marginBottom: undefined,
-              justifyContent: undefined,
-              paddingTop: insets.top,
-              paddingBottom: insets.bottom,
-            }}
-            contentContainerStyle={[
-              styles.countries,
+            style={[
+              styles.modal,
               {
-                justifyContent: undefined,
+                backgroundColor: theme.colors.background,
+                paddingTop: insets.top,
+                paddingBottom: insets.bottom,
               },
+              modalStyle,
             ]}
+            contentContainerStyle={[styles.countries, modalContainerStyle]}
             visible={visible}
             onDismiss={() => setVisible(false)}
           >
@@ -220,10 +218,16 @@ const styles = StyleSheet.create({
   flex1: {
     flex: isIOS ? undefined : 1,
   },
+  modal: {
+    marginTop: undefined,
+    marginBottom: undefined,
+    justifyContent: undefined,
+  },
   countries: {
     padding: 16,
     flex: isIOS ? undefined : 1,
     marginBottom: isIOS ? 270 : undefined,
+    justifyContent: undefined,
   },
   searchbox: {
     flexDirection: 'row',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { TextInput as NativeTextInput } from 'react-native';
+import type { TextInput as NativeTextInput, StyleProp, ViewStyle } from 'react-native';
 import type { TextInputProps } from 'react-native-paper';
 
 export type RNPaperTextInputRef = Pick<
@@ -17,6 +17,8 @@ export interface PhoneNumberInputProps extends Omit<TextInputProps, 'value' | 'o
   phoneNumber?: string;
   setPhoneNumber: React.Dispatch<React.SetStateAction<string | undefined>>;
   showFirstOnList?: string[];
+  modalStyle?: StyleProp<ViewStyle>;
+  modalContainerStyle?: StyleProp<ViewStyle>;
 }
 
 export interface CountryPickerRef {
@@ -28,4 +30,6 @@ export interface CountryPickerProps extends Omit<TextInputProps, 'value' | 'onCh
   country?: string;
   setCountry: React.Dispatch<React.SetStateAction<string>>;
   showFirstOnList?: string[];
+  modalStyle?: StyleProp<ViewStyle>;
+  modalContainerStyle?: StyleProp<ViewStyle>;
 }


### PR DESCRIPTION
- Adds back button to make it easy to dismiss, as suggested by @OmarThinks in #3. 
- Also adds `modalStyle` and `modalContainerStyle` for additional user customization.
  - Updates `example` app to use the newly introduced props.